### PR TITLE
rename position attribute in isf_position

### DIFF
--- a/src/ISFGLProgram.js
+++ b/src/ISFGLProgram.js
@@ -16,7 +16,7 @@ ISFGLProgram.prototype.getUniformLocation = function getUniformLocation(name) {
 
 ISFGLProgram.prototype.bindVertices = function bindVertices() {
   this.use();
-  const positionLocation = this.gl.getAttribLocation(this.program, 'position');
+  const positionLocation = this.gl.getAttribLocation(this.program, 'isf_position');
   this.buffer = this.gl.createBuffer();
   this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.buffer);
   const vertexArray = new Float32Array(

--- a/src/ISFParser.js
+++ b/src/ISFParser.js
@@ -260,7 +260,7 @@ precision highp float;
 precision highp int;
 void isf_vertShaderInit();
 
-attribute vec2 position; // -1..1
+attribute vec2 isf_position; // -1..1
 
 uniform int     PASSINDEX;
 uniform vec2    RENDERSIZE;
@@ -271,7 +271,7 @@ vec2    isf_fragCoord; // Pixel Space
 
 [[main]]
 void isf_vertShaderInit(void)  {
-gl_Position = vec4( position, 0.0, 1.0 );
+gl_Position = vec4( isf_position, 0.0, 1.0 );
   isf_FragNormCoord = vec2((gl_Position.x+1.0)/2.0, (gl_Position.y+1.0)/2.0);
   isf_fragCoord = floor(isf_FragNormCoord * RENDERSIZE);
   [[functions]]

--- a/src/ISFRenderer.js
+++ b/src/ISFRenderer.js
@@ -380,7 +380,7 @@ ISFRenderer.prototype.cleanup = function cleanup() {
   }
 };
 
-ISFRenderer.prototype.basicVertexShader = "precision mediump float;\nprecision mediump int;\nattribute vec2 position; // -1..1\nvarying vec2 texCoord;\n\nvoid main(void) {\n  // Since webgl doesn't support ftransform, we do this by hand.\n  gl_Position = vec4(position, 0, 1);\n  texCoord = position;\n}\n";
+ISFRenderer.prototype.basicVertexShader = "precision mediump float;\nprecision mediump int;\nattribute vec2 isf_position; // -1..1\nvarying vec2 texCoord;\n\nvoid main(void) {\n  // Since webgl doesn't support ftransform, we do this by hand.\n  gl_Position = vec4(isf_position, 0, 1);\n  texCoord = isf_position;\n}\n";
 
 ISFRenderer.prototype.basicFragmentShader = 'precision mediump float;\nuniform sampler2D tex;\nvarying vec2 texCoord;\nvoid main()\n{\n  gl_FragColor = texture2D(tex, texCoord * 0.5 + 0.5);\n  //gl_FragColor = vec4(texCoord.x);\n}';
 


### PR DESCRIPTION
Hi,

While i was using interactive-shader-format-js, i got name colision between my shaders and the attribute ```position```. While other isf variables are prefixed by 'isf_', for some reason this particular variable ```position``` is not prefixed.

In this pull request, it just change the name to ```isf_position```
