### PR TITLE
Fix/isf parser

### DIFF
--- a/src/ISFParser.js
+++ b/src/ISFParser.js
@@ -133,20 +133,14 @@ ISFParser.prototype.replaceSpecialFunctions = function replaceSpecialFunctions(s
   source = source.replace(regex, (fullMatch, innerMatch) => `texture2D(${innerMatch}, isf_FragNormCoord)`);
 
   // IMG_PIXEL
-  regex = /IMG_PIXEL\((.+?)\)/g;
-  source = source.replace(regex, (fullMatch, innerMatch) => {
-    const results = innerMatch.split(',');
-    const sampler = results[0];
-    const coord = results[1];
+  regex = /IMG_PIXEL\((.+?)\s?,\s?(.+?\)?\.?.*)\)/g;
+  source = source.replace(regex, (fullMatch, sampler, coord) => {
     return `texture2D(${sampler}, (${coord}) / RENDERSIZE)`;
   });
 
   // IMG_NORM_PIXEL
-  regex = /IMG_NORM_PIXEL\((.+?)\)/g;
-  source = source.replace(regex, (fullMatch, innerMatch) => {
-    const results = innerMatch.split(',');
-    const sampler = results[0];
-    const coord = results[1];
+  regex = /IMG_NORM_PIXEL\((.+?)\s?,\s?(.+?\)?\.?.*)\)/g;
+  source = source.replace(regex, (fullMatch, sampler, coord) => {
     return `VVSAMPLER_2DBYNORM(${sampler}, _${sampler}_imgRect, _${sampler}_imgSize, _${sampler}_flip, ${coord})`;
   });
 

--- a/tests/assets/img_norm_pixel_isf.fs
+++ b/tests/assets/img_norm_pixel_isf.fs
@@ -1,0 +1,28 @@
+/*{
+  "CATEGORIES": [
+      "Testing"
+  ],
+  "CREDIT": "NERDDISCO",
+  "INPUTS": [
+      {
+          "NAME": "inputImage",
+          "TYPE": "image"
+      }
+  ],
+  "ISFVSN": "2"
+}
+*/
+
+void main() {
+    float x = isf_FragNormCoord.x;
+    float y = isf_FragNormCoord.y;
+    vec4 color = IMG_NORM_PIXEL(inputImage, isf_FragNormCoord);
+    color = IMG_NORM_PIXEL(inputImage, vec2(isf_FragNormCoord));
+    color = IMG_NORM_PIXEL(inputImage, vec2(isf_FragNormCoord.x, isf_FragNormCoord.y));
+    color = IMG_NORM_PIXEL(inputImage, vec2(x, y));
+    color = IMG_NORM_PIXEL(inputImage, vec3(x, y, x).xy);
+    color = IMG_NORM_PIXEL(inputImage, vec4(x, y, x, y).xy);
+    color = IMG_NORM_PIXEL(inputImage,vec4(x,y,x,y).xy);
+  
+    gl_FragColor = color;
+  }

--- a/tests/assets/img_pixel_isf.fs
+++ b/tests/assets/img_pixel_isf.fs
@@ -1,0 +1,27 @@
+/*{
+  "CATEGORIES": [
+      "Testing"
+  ],
+  "CREDIT": "NERDDISCO",
+  "INPUTS": [
+      {
+          "NAME": "inputImage",
+          "TYPE": "image"
+      }
+  ],
+  "ISFVSN": "2"
+}
+*/
+
+void main() {
+  float x = gl_FragCoord.x;
+  float y = gl_FragCoord.y;
+  vec4 color = IMG_PIXEL(inputImage, gl_FragCoord.xy);
+  color = IMG_PIXEL(inputImage, vec2(gl_FragCoord.xy));
+  color = IMG_PIXEL(inputImage, vec2(gl_FragCoord.x, gl_FragCoord.y));
+  color = IMG_PIXEL(inputImage, vec2(x, y));
+  color = IMG_PIXEL(inputImage, vec3(x, y, x).xy);
+  color = IMG_PIXEL(inputImage, vec4(x, y, x, y).xy);
+
+  gl_FragColor = color;
+}

--- a/tests/parser-test.js
+++ b/tests/parser-test.js
@@ -78,13 +78,43 @@ test('IMG_NORM_PIXEL to VVSAMPLER_2DBYNORM', function (t) {
     'vec2(x, y)',
     'vec3(x, y, x).xy',
     'vec4(x, y, x, y).xy',
-    'vec4(x,y,x,y).xy',
   ];
 
   variableTypes.forEach((variable) => {
     const test = {
       toReplace: IMG_NORM_PIXEL(variable),
       expectedReplacement: VVSAMPLER_2DBYNORM(variable),
+      expectedIndex: -1
+    };
+
+    t.not(fragmentShader.indexOf(test.expectedReplacement), test.expectedIndex, test.toReplace);
+  });
+  
+  t.end();
+});
+
+test('IMG_PIXEL to texture2D', function (t) {
+  let src = assetLoad('img_pixel_isf.fs');
+  const parser = new ISFParser();
+  parser.parse(src);
+  const { fragmentShader } = parser;
+
+  const IMG_PIXEL = (variable) => `IMG_PIXEL(inputImage, ${variable});`;
+  const TEXTURE2D = (variable) => `texture2D(inputImage, (${variable}) / RENDERSIZE);`;
+
+  const variableTypes = [
+    'gl_FragCoord.xy',
+    'vec2(gl_FragCoord.xy)',
+    'vec2(gl_FragCoord.x, gl_FragCoord.y)',
+    'vec2(x, y)',
+    'vec3(x, y, x).xy',
+    'vec4(x, y, x, y).xy',
+  ];
+
+  variableTypes.forEach((variable) => {
+    const test = {
+      toReplace: IMG_PIXEL(variable),
+      expectedReplacement: TEXTURE2D(variable),
       expectedIndex: -1
     };
 

--- a/tests/parser-test.js
+++ b/tests/parser-test.js
@@ -62,32 +62,34 @@ test('Bad metadata gives error line', function(t) {
   t.end();
 });
 
-test('IMG_NORM_PIXEL to VVSAMPLER_2DBYNORM', function(t) {
+test('IMG_NORM_PIXEL to VVSAMPLER_2DBYNORM', function (t) {
   let src = assetLoad('img_norm_pixel_isf.fs');
   const parser = new ISFParser();
   parser.parse(src);
   const { fragmentShader } = parser;
 
-  const test1 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, isf_FragNormCoord);`
-  t.not(fragmentShader.indexOf(test1), -1, 'IMG_NORM_PIXEL(inputImage, isf_FragNormCoord);');
+  const IMG_NORM_PIXEL = (variable) => `IMG_NORM_PIXEL(inputImage, ${variable});`;
+  const VVSAMPLER_2DBYNORM = (variable) => `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, ${variable});`;
 
-  const test2 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, vec2(isf_FragNormCoord));`
-  t.not(fragmentShader.indexOf(test2), -1, 'IMG_NORM_PIXEL(inputImage, vec2(isf_FragNormCoord));');
+  const variableTypes = [
+    'isf_FragNormCoord',
+    'vec2(isf_FragNormCoord)',
+    'vec2(isf_FragNormCoord.x, isf_FragNormCoord.y)',
+    'vec2(x, y)',
+    'vec3(x, y, x).xy',
+    'vec4(x, y, x, y).xy',
+    'vec4(x,y,x,y).xy',
+  ];
 
-  const test3 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, vec2(isf_FragNormCoord.x, isf_FragNormCoord.y));`
-  t.not(fragmentShader.indexOf(test3), -1, 'IMG_NORM_PIXEL(inputImage, vec2(isf_FragNormCoord.x, isf_FragNormCoord.y));');
+  variableTypes.forEach((variable) => {
+    const test = {
+      toReplace: IMG_NORM_PIXEL(variable),
+      expectedReplacement: VVSAMPLER_2DBYNORM(variable),
+      expectedIndex: -1
+    };
 
-  const test4 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, vec2(x, y));`
-  t.not(fragmentShader.indexOf(test4), -1, 'IMG_NORM_PIXEL(inputImage, vec2(x, y));');
-
-  const test5 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, vec3(x, y, x).xy);`
-  t.not(fragmentShader.indexOf(test5), -1, 'IMG_NORM_PIXEL(inputImage, vec3(x, y, x).xy);');
-
-  const test6 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, vec4(x, y, x, y).xy);`
-  t.not(fragmentShader.indexOf(test6), -1, 'IMG_NORM_PIXEL(inputImage, vec4(x, y, x, y).xy);');
-
-  const test7 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, vec4(x,y,x,y).xy);`
-  t.not(fragmentShader.indexOf(test7), -1, 'IMG_NORM_PIXEL(inputImage,vec4(x,y,x,y).xy);');
-
+    t.not(fragmentShader.indexOf(test.expectedReplacement), test.expectedIndex, test.toReplace);
+  });
+  
   t.end();
-})
+});

--- a/tests/parser-test.js
+++ b/tests/parser-test.js
@@ -61,3 +61,33 @@ test('Bad metadata gives error line', function(t) {
   t.equal(0, 0);
   t.end();
 });
+
+test('IMG_NORM_PIXEL to VVSAMPLER_2DBYNORM', function(t) {
+  let src = assetLoad('img_norm_pixel_isf.fs');
+  const parser = new ISFParser();
+  parser.parse(src);
+  const { fragmentShader } = parser;
+
+  const test1 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, isf_FragNormCoord);`
+  t.not(fragmentShader.indexOf(test1), -1, 'IMG_NORM_PIXEL(inputImage, isf_FragNormCoord);');
+
+  const test2 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, vec2(isf_FragNormCoord));`
+  t.not(fragmentShader.indexOf(test2), -1, 'IMG_NORM_PIXEL(inputImage, vec2(isf_FragNormCoord));');
+
+  const test3 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, vec2(isf_FragNormCoord.x, isf_FragNormCoord.y));`
+  t.not(fragmentShader.indexOf(test3), -1, 'IMG_NORM_PIXEL(inputImage, vec2(isf_FragNormCoord.x, isf_FragNormCoord.y));');
+
+  const test4 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, vec2(x, y));`
+  t.not(fragmentShader.indexOf(test4), -1, 'IMG_NORM_PIXEL(inputImage, vec2(x, y));');
+
+  const test5 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, vec3(x, y, x).xy);`
+  t.not(fragmentShader.indexOf(test5), -1, 'IMG_NORM_PIXEL(inputImage, vec3(x, y, x).xy);');
+
+  const test6 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, vec4(x, y, x, y).xy);`
+  t.not(fragmentShader.indexOf(test6), -1, 'IMG_NORM_PIXEL(inputImage, vec4(x, y, x, y).xy);');
+
+  const test7 = `VVSAMPLER_2DBYNORM(inputImage, _inputImage_imgRect, _inputImage_imgSize, _inputImage_flip, vec4(x,y,x,y).xy);`
+  t.not(fragmentShader.indexOf(test7), -1, 'IMG_NORM_PIXEL(inputImage,vec4(x,y,x,y).xy);');
+
+  t.end();
+})


### PR DESCRIPTION
The regex for both `IMG_PIXEL` and `IMG_NORM_PIXEL` is wrong for the following cases:

```
color = IMG_NORM_PIXEL(inputImage, vec2(isf_FragNormCoord.x, isf_FragNormCoord.y));
color = IMG_NORM_PIXEL(inputImage, vec2(x, y));
color = IMG_NORM_PIXEL(inputImage, vec3(x, y, x).xy);
color = IMG_NORM_PIXEL(inputImage, vec4(x, y, x, y).xy);
```
See https://editor.isf.video/shaders/60c915d8d4849b0013135e38

And the same goes for IMG_PIXEL, see https://editor.isf.video/shaders/60d0e047d4849b0013135e46

This PR is fixing the regex and adding some tests to make sure that the ISFParser.js is doing the right thing. 